### PR TITLE
Add two instances of each application

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -3,6 +3,7 @@ applications:
 - name: beckley-loader
   domain: 18f.gov
   memory: 2G
+  instances: 2
   env:
     BECKLEY_LOADER: true
   services:
@@ -10,5 +11,6 @@ applications:
 - name: beckley
   domain: 18f.gov
   memory: 512M
+  instances: 2
   services:
    - beckley-es


### PR DESCRIPTION
Per the best production practices in the Before You Ship guide (https://pages.18f.gov/before-you-ship/infrastructure/good-production-practices/#scalability) each component should have _at least_ two instances. Right now we just have beckley and its corresponding components with 1 instance which results in occasional downtime.

cc @afeld and @dlapiduz as this might require quota adjustments as well
